### PR TITLE
add sample loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "bytemuck"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+
+[[package]]
 name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +291,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +486,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,7 +591,10 @@ dependencies = [
  "crossterm",
  "glicol",
  "glicol_synth",
+ "rayon",
+ "symphonia",
  "tui",
+ "walkdir",
 ]
 
 [[package]]
@@ -613,6 +680,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
@@ -652,7 +728,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
  "windows-sys",
@@ -785,6 +861,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "meval"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +971,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "libc",
 ]
 
 [[package]]
@@ -1098,6 +1193,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f851a03551ceefd30132e447f07f96cb7011d6b658374f3aed847333adb5559"
 
 [[package]]
+name = "rayon"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,6 +1376,138 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "symphonia"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3671dd6f64f4f9d5c87179525054cfc1f60de23ba1f193bd6ceab812737403f1"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-flac",
+ "symphonia-codec-adpcm",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-mkv",
+ "symphonia-format-ogg",
+ "symphonia-format-wav",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc2deed3204967871ba60f913378f95820cb47a2fe9b2eef5a9eedb417dfdc8"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-codec-adpcm"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a5cfb8d4405e26eb9593157dc45b05e102b8d774b38ed2a95946d6bb9e26e3e"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb9a9f0b9991cccf3217b74644af412d5d082a4815e5e2943f26e0ecabdf3c9"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfed6f7b6bfa21d7cef1acefc8eae5db80df1608a1aca91871b07cbd28d7b74"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b9567e2d8a5f866b2f94f5d366d811e0c6826babcff6d37de9e1a6690d38869"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd22f2def8c8f078495ad66111648bfc7d5222ee33774f2077cb665588f3119"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "474df6e86b871dcb56913130bada1440245f483057c4a2d8a2981455494c4439"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-wav"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06679bd5646b3037300f88891dfc8a6e1cc4e1133206cc17a98e5d7c22f88296"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acd35c263223ef6161000be79b124a75de3e065eea563bf3ef169b3e94c7bb2e"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce340a6c33ac06cb42de01220308ec056e8a2a3d5cc664aaf34567392557136b"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,12 +1624,11 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,15 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.1.8", features = ["derive"] }
-glicol = "0.13.1"
+glicol = { version = "0.13.1", features = ["use-samples"] }
 glicol_synth = "0.13.1"
 cpal =  "0.15.0"
 # chrono = "0.4.23"
 crossterm = "*"
 tui = "*"
+symphonia = { version = "0.5.2", features = ["wav"] }
+rayon = "1.7.0"
+walkdir = "2.3.3"
 # dasp_ring_buffer = "0.11.0"
 
 [features]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod samples;
+
 use std::fs::{File, metadata};
 use std::io::{BufRead, BufReader};
 use std::time::{Instant, Duration}; // , SystemTime, UNIX_EPOCH
@@ -284,6 +286,7 @@ where
     let sr = config.sample_rate.0 as usize;
 
     let mut engine = Engine::<BLOCK_SIZE>::new();
+    samples::load_samples_from_env(&mut engine);
 
     let mut code = String::new();
     let ptr = unsafe { code.as_bytes_mut().as_mut_ptr() };

--- a/src/samples.rs
+++ b/src/samples.rs
@@ -1,0 +1,183 @@
+use crate::BLOCK_SIZE;
+use anyhow::Context;
+use glicol::Engine;
+use rayon::prelude::*;
+use std::{fs::File, path::Path};
+use symphonia::core::{
+    audio::Signal, codecs::DecoderOptions, formats::FormatReader, io::MediaSourceStream,
+    probe::Hint,
+};
+
+pub fn load_samples_from_env(engine: &mut Engine<BLOCK_SIZE>) {
+    let key = "GLICOL_CLI_SAMPLES_PATH";
+
+    if let Some(paths) = std::env::var_os(key) {
+        for path in std::env::split_paths(&paths) {
+            if let Err(error) = load_samples_from_dir(engine, &path) {
+                eprintln!("failed to load samples from {:?}, reason: {}", path, error);
+            }
+        }
+    }
+}
+
+fn load_samples_from_dir(
+    engine: &mut Engine<BLOCK_SIZE>,
+    dir: impl AsRef<Path>,
+) -> anyhow::Result<()> {
+    let walk_dir = walkdir::WalkDir::new(dir)
+        .min_depth(1)
+        .max_depth(2)
+        .into_iter()
+        .filter_entry(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .map(|s| !s.starts_with('.'))
+                .unwrap_or(false)
+        })
+        .filter_map(|entry| {
+            entry.ok().filter(|entry| {
+                AsRef::<std::path::Path>::as_ref(&entry.file_name())
+                    .extension()
+                    .map(|ext| ext == "wav")
+                    .unwrap_or(false)
+            })
+        })
+        .map(|entry| (entry.path().to_path_buf(), entry.depth()))
+        .collect::<Vec<_>>();
+
+    for (sample, name) in walk_dir
+        .par_iter()
+        .filter_map(|(path, depth)| {
+            let prefix = if *depth == 2 {
+                path.parent()
+                    .unwrap()
+                    .file_name()
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+            } else {
+                ""
+            };
+
+            let name = format!(
+                "\\{}{}",
+                prefix,
+                path.file_stem().unwrap().to_str().unwrap()
+            );
+
+            load_sample(path).ok().zip(Some(name))
+        })
+        .collect::<Vec<_>>()
+    {
+        let sample_buffer = Box::leak(sample.buffer.into_boxed_slice());
+        engine.add_sample(&name, sample_buffer, sample.channels, sample.sr);
+    }
+
+    Ok(())
+}
+
+struct Sample {
+    buffer: Vec<f32>,
+    sr: usize,
+    channels: usize,
+}
+
+fn load_sample(path: impl AsRef<Path>) -> anyhow::Result<Sample> {
+    let mut hint = Hint::new();
+
+    if let Some(extension) = path.as_ref().extension() {
+        if let Some(extension_str) = extension.to_str() {
+            hint.with_extension(extension_str);
+        }
+    }
+
+    let source = Box::new(File::open(path)?);
+
+    let mss = MediaSourceStream::new(source, Default::default());
+
+    match symphonia::default::get_probe().format(
+        &hint,
+        mss,
+        &Default::default(),
+        &Default::default(),
+    ) {
+        Ok(probed) => decode(probed.format, &DecoderOptions { verify: false })
+            .context("Couldn't decode sample"),
+        Err(err) => {
+            anyhow::bail!("input format not supported: {err}");
+        }
+    }
+}
+
+fn decode(
+    mut reader: Box<dyn FormatReader>,
+    decode_opts: &DecoderOptions,
+) -> anyhow::Result<Sample> {
+    let track = reader.default_track().unwrap();
+    let track_id = track.id;
+
+    let sr = track
+        .codec_params
+        .sample_rate
+        .ok_or(anyhow::anyhow!("Couldn't get sample rate"))? as usize;
+
+    let mut decoder = symphonia::default::get_codecs().make(&track.codec_params, decode_opts)?;
+
+    let channels = track
+        .codec_params
+        .channels
+        .ok_or(anyhow::anyhow!("Couldn't get channel info"))?
+        .count();
+
+    if channels > 2 {
+        anyhow::bail!("unsupported channel number");
+    }
+
+    let mut channel_0: Vec<f32> = vec![];
+    let mut channel_1: Vec<f32> = vec![];
+
+    let result = loop {
+        let packet = match reader.next_packet() {
+            Ok(packet) => packet,
+            Err(err) => break Err(err),
+        };
+
+        if packet.track_id() != track_id {
+            continue;
+        }
+
+        let decoded = match decoder.decode(&packet) {
+            Ok(decoded) => decoded,
+            Err(err) => break Err(err),
+        };
+
+        let mut buffer = decoded.make_equivalent::<f32>();
+
+        decoded.convert(&mut buffer);
+        channel_0.extend(buffer.chan(0));
+
+        if channels == 2 {
+            channel_1.extend(buffer.chan(1));
+        }
+    };
+
+    match result {
+        Err(symphonia::core::errors::Error::IoError(err))
+            if err.kind() == std::io::ErrorKind::UnexpectedEof
+                && err.to_string() == "end of stream" =>
+        {
+            Ok(())
+        }
+        _ => result,
+    }?;
+
+    // if mono then channel_1 would be empty, so no change here
+    channel_0.extend(channel_1);
+
+    Ok(Sample {
+        buffer: channel_0,
+        sr,
+        channels,
+    })
+}


### PR DESCRIPTION
I know there is already a branch with some support already, but I ended up writing this anyway, so I'm sharing it here it in case someone finds it useful while that's finished (although I wouldn't mind working on getting this merged neither).

Files are read from the directories in the `GLICOL_CLI_SAMPLES_PATH` environment variable. There can be multiple directories, separated by `;` like with `PATH`.

Files in the top level are imported with the name directly, while files in a directory have the directory name as a prefix. For example, I'm currently using the following config.

```
export GLICOL_CLI_SAMPLES_PATH="$HOME/Sources/glicol/js/assets"
export GLICOL_CLI_SAMPLES_PATH="$HOME/Sources/Dirt-Samples/:$GLICOL_CLI_SAMPLES_PATH"
```

Which allows using `sp \guitar` (guitar.wav in glicol/js/assets) and `\peri007_xbigclang` (007_xbigclang.wav in Dirt-Samples/peri`.