### PR TITLE
Add messages console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,9 @@ dependencies = [
  "glicol_synth",
  "ratatui",
  "rayon",
+ "ringbuf",
  "symphonia",
+ "tracing-subscriber",
  "walkdir",
 ]
 
@@ -943,6 +945,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1023,12 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1236,6 +1254,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ringbuf"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79abed428d1fd2a128201cec72c5f6938e2da607c6f3745f769fabea399d950a"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,6 +1298,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1535,6 +1571,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +1604,41 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1595,6 +1676,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,7 @@ dependencies = [
  "rayon",
  "ringbuf",
  "symphonia",
+ "tracing",
  "tracing-subscriber",
  "walkdir",
 ]
@@ -1120,6 +1121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,6 +1611,28 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ symphonia = { version = "0.5.3", features = ["wav"] }
 rayon = "1.8.0"
 ringbuf = "0.3"
 walkdir = "2.4.0"
+tracing = "0.1"
 tracing-subscriber = "0.3"
 # dasp_ring_buffer = "0.11.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ crossterm = "0.27.0"
 ratatui = "0.24.0"
 symphonia = { version = "0.5.3", features = ["wav"] }
 rayon = "1.8.0"
+ringbuf = "0.3"
 walkdir = "2.4.0"
+tracing-subscriber = "0.3"
 # dasp_ring_buffer = "0.11.0"
 
 [features]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod recent_lines;
 mod samples;
 mod tui;
 
@@ -61,6 +62,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     // let scope = args.scope;
     let device = args.device;
     let bpm = args.bpm;
+
+    // keep logs
+    const RECENT_LINES_COUNT: usize = 100;
+    let console_buffer = recent_lines::register_tracer(RECENT_LINES_COUNT);
 
     // setup terminal
     enable_raw_mode()?;
@@ -168,6 +173,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let tick_rate = Duration::from_millis(16);
     let res = run_app(
+        console_buffer,
         &mut terminal,
         tick_rate,
         samples_l_ptr,

--- a/src/recent_lines.rs
+++ b/src/recent_lines.rs
@@ -1,0 +1,144 @@
+use std::{
+    io, mem,
+    sync::{Arc, Mutex, MutexGuard},
+};
+
+use ringbuf::{HeapRb, Rb};
+
+/// Register a tracing subscriber outputting to a [`ShareableRecentLinesBuffer`] with given capacity.
+pub(super) fn register_tracer(capacity: usize) -> ShareableRecentLinesBuffer {
+    let buffer = ShareableRecentLinesBuffer(Arc::new(Mutex::new(RecentLinesBuffer::new(capacity))));
+
+    tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(buffer.clone())
+        .init();
+
+    buffer
+}
+
+/// Keep most recent lines written to it.
+pub(crate) struct RecentLinesBuffer {
+    /// Lines kept
+    lines: HeapRb<String>,
+
+    /// Line currently being written
+    current_line: Vec<u8>,
+}
+
+impl RecentLinesBuffer {
+    /// Create a writer keeping at most `capacity` lines
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            lines: HeapRb::new(capacity),
+            current_line: Vec::new(),
+        }
+    }
+
+    /// Get the most recent lines
+    pub fn read(&self) -> Vec<String> {
+        self.lines.iter().cloned().collect()
+    }
+}
+
+impl io::Write for RecentLinesBuffer {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut lines = buf.split(|b| *b == b'\n');
+        let mut read = 0;
+
+        // complete current line
+        let first_line = lines.next().expect("at least a single elem");
+        read += first_line.len();
+        self.current_line.extend_from_slice(first_line);
+
+        for line in lines {
+            read += 1 + line.len(); // with separator
+
+            let previous_line = mem::replace(&mut self.current_line, Vec::from(line));
+            self.lines.push_overwrite(
+                String::from_utf8(previous_line)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+            );
+        }
+
+        Ok(read)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(()) // nothing to do
+    }
+}
+
+// can be inlined to inner type after merge of
+// https://github.com/tokio-rs/tracing/pull/2760
+#[derive(Clone)]
+pub(crate) struct ShareableRecentLinesBuffer(pub(super) Arc<Mutex<RecentLinesBuffer>>);
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for ShareableRecentLinesBuffer {
+    type Writer = MutexGuardWriter<'a, RecentLinesBuffer>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        MutexGuardWriter(self.0.lock().expect("lock poisoned"))
+    }
+}
+
+// taken from tracing-subscriber/src/fmt/writer.rs
+// can be removed when above is not needed anymore
+pub(crate) struct MutexGuardWriter<'a, W: io::Write + 'a>(MutexGuard<'a, W>);
+
+impl<'a, W> io::Write for MutexGuardWriter<'a, W>
+where
+    W: io::Write + 'a,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        self.0.write_vectored(bufs)
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.0.write_all(buf)
+    }
+
+    fn write_fmt(&mut self, fmt: std::fmt::Arguments<'_>) -> io::Result<()> {
+        self.0.write_fmt(fmt)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RecentLinesBuffer;
+
+    use std::io::Write;
+
+    #[test]
+    fn only_show_full_lines() {
+        let mut last_written = RecentLinesBuffer::new(10);
+
+        write!(&mut last_written, "not ended line").unwrap();
+        assert!(last_written.read().is_empty());
+
+        writeln!(&mut last_written, " is now ended").unwrap();
+        assert_eq!(last_written.read(), vec!["not ended line is now ended"]);
+    }
+
+    #[test]
+    fn keep_only_recent_lines() {
+        let mut last_written = RecentLinesBuffer::new(3);
+
+        writeln!(&mut last_written, "a").unwrap();
+        writeln!(&mut last_written, "b").unwrap();
+        writeln!(&mut last_written, "c").unwrap();
+        assert_eq!(last_written.read(), vec!["a", "b", "c"]);
+
+        writeln!(&mut last_written, "d").unwrap();
+        assert_eq!(last_written.read(), vec!["b", "c", "d"]);
+    }
+}

--- a/src/samples.rs
+++ b/src/samples.rs
@@ -7,6 +7,7 @@ use symphonia::core::{
     audio::Signal, codecs::DecoderOptions, formats::FormatReader, io::MediaSourceStream,
     probe::Hint,
 };
+use tracing::error;
 
 pub fn load_samples_from_env(engine: &mut Engine<BLOCK_SIZE>) {
     let key = "GLICOL_CLI_SAMPLES_PATH";
@@ -14,7 +15,7 @@ pub fn load_samples_from_env(engine: &mut Engine<BLOCK_SIZE>) {
     if let Some(paths) = std::env::var_os(key) {
         for path in std::env::split_paths(&paths) {
             if let Err(error) = load_samples_from_dir(engine, &path) {
-                eprintln!("failed to load samples from {:?}, reason: {}", path, error);
+                error!(?path, "failed to load samples: {error:#}");
             }
         }
     }


### PR DESCRIPTION
add a small console on the bottom of the screen showing info/warn/error messages. it uses the [tracing](https://crates.io/crates/tracing) framework which is quite used around (so info/warn/error messages from deps will be forwarded there too).

I added an explicit `engine.update()` step after code update to actually get some compiling error which aren't really human-readable but at least, it's not silent. is there another way to get an engine error maybe? also, having it in the audio loop seems risky depending on the size of the new file. WDYT?

potentially closes #24 depending on what you had in mind.