### PR TITLE
Use notify for file reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a9b73a36529d9c47029b9fb3a6f0ea3cc916a261195352ba19e770fc1748b2"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
 dependencies = [
  "cfg-if",
 ]
@@ -560,16 +570,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fasteval"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f4cdac9e4065d7c48e30770f8665b8cef9a3a73a63a4056a33a5f395bc7cf75"
 
 [[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.4.1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "generic-array"
@@ -617,10 +664,12 @@ dependencies = [
  "crossterm",
  "glicol",
  "glicol_synth",
+ "notify",
  "ratatui",
  "rayon",
  "ringbuf",
  "symphonia",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
  "walkdir",
@@ -722,6 +771,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +861,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,9 +900,9 @@ checksum = "c172ea7099cef89eb5a1a6e1f55d79a753823a0201d362f6ec5508028efcf4ed"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libloading"
@@ -824,6 +913,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "lock_api"
@@ -946,6 +1041,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.4.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,7 +1163,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -1220,6 +1334,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1397,19 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.38.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+dependencies = [
+ "bitflags 2.4.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rustversion"
@@ -1555,6 +1691,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.4.1",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1869,6 +2018,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,6 +2057,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1909,6 +2082,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1923,6 +2102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1933,6 +2118,12 @@ name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1947,6 +2138,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,6 +2154,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1971,6 +2174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,6 +2190,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,16 @@ cpal = "0.15.2"
 crossterm = "0.27.0"
 ratatui = "0.24.0"
 symphonia = { version = "0.5.3", features = ["wav"] }
+notify = "6"
 rayon = "1.8.0"
 ringbuf = "0.3"
 walkdir = "2.4.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 # dasp_ring_buffer = "0.11.0"
+
+[dev-dependencies]
+tempfile = "3"
 
 [features]
 default = []

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,0 +1,179 @@
+use std::{fs, path::Path, sync};
+
+use anyhow::{Context, Result};
+use notify::{
+    event::{Event, EventKind, ModifyKind, RenameMode},
+    RecursiveMode, Watcher,
+};
+use tracing::{debug, error, info};
+
+/// Watch the given file at path and stream back its content
+///
+/// Fails to detected when the path is replaced by an empty file
+pub(crate) fn watch_path(
+    path: &Path,
+) -> Result<(impl notify::Watcher, sync::mpsc::Receiver<String>)> {
+    // Event's paths are absolute
+    let path = path.canonicalize().context("canonicalize file path")?;
+    let (sender, receiver) = sync::mpsc::channel();
+
+    let content = fs::read_to_string(&path).context("initial file read")?;
+    sender.send(content).unwrap(); // receiver is still there
+
+    let mut watcher = {
+        let path = path.clone();
+        notify::recommended_watcher(move |res: Result<Event, _>| {
+            match res {
+                Ok(event)
+                    if event.paths.contains(&path)
+                        && matches!(
+                            event.kind,
+                            EventKind::Modify(
+                                ModifyKind::Data(_) | ModifyKind::Name(RenameMode::To)
+                            )
+                        ) =>
+                {
+                    info!("changed file, loading content");
+
+                    match fs::read_to_string(&path) {
+                        Ok(code) => {
+                            if sender.send(code).is_err() {
+                                debug!("file watcher found changes but receiver is gone");
+                            }
+                        }
+                        Err(e) => error!("read file: {e}"),
+                    }
+                }
+                Ok(_) => {} // not relevant
+                Err(e) => error!("watching file's parent: {e}"),
+            }
+        })
+    }
+    .context("create file's parent watcher")?;
+
+    watcher
+        .watch(
+            path.parent().context("file doesn't have a parent")?,
+            RecursiveMode::NonRecursive,
+        )
+        .context("add parent directory watch")?;
+
+    Ok((watcher, receiver))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::watch_path;
+
+    use std::{
+        fs::{self, File},
+        io::Write,
+        sync::mpsc::TryRecvError,
+    };
+
+    use tempfile::TempDir;
+
+    #[test]
+    fn show_initial_content() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("file");
+        fs::write(&file, "initial").unwrap();
+
+        let (_watcher, changes) = watch_path(&file).unwrap();
+        assert_eq!(changes.recv().unwrap(), "initial");
+
+        assert_eq!(changes.try_recv(), Err(TryRecvError::Empty));
+    }
+
+    #[test]
+    fn does_nothing_on_read() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("file");
+        fs::write(&file, "initial").unwrap();
+
+        let (_watcher, changes) = watch_path(&file).unwrap();
+        assert_eq!(changes.recv().unwrap(), "initial");
+
+        fs::read(file).unwrap();
+
+        assert_eq!(changes.try_recv(), Err(TryRecvError::Empty));
+    }
+
+    #[test]
+    fn handle_recreated() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("file");
+        fs::write(&file, "initial").unwrap();
+
+        let (_watcher, changes) = watch_path(&file).unwrap();
+        assert_eq!(changes.recv().unwrap(), "initial");
+
+        fs::remove_file(&file).unwrap();
+        fs::write(&file, "recreated").unwrap();
+        assert_eq!(changes.recv().unwrap(), "recreated");
+
+        assert_eq!(changes.try_recv(), Err(TryRecvError::Empty));
+    }
+
+    #[test]
+    fn handle_renaming_in_place() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("file");
+        fs::write(&file, "initial").unwrap();
+
+        let (_watcher, changes) = watch_path(&file).unwrap();
+        assert_eq!(changes.recv().unwrap(), "initial");
+
+        let other_file = dir.path().join("other file");
+        fs::write(&other_file, "renamed").unwrap();
+        fs::rename(&other_file, &file).unwrap();
+        assert_eq!(changes.recv().unwrap(), "renamed");
+
+        assert_eq!(changes.try_recv(), Err(TryRecvError::Empty));
+    }
+
+    #[test]
+    fn handle_truncation() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("file");
+        fs::write(&file, "initial").unwrap();
+
+        let (_watcher, changes) = watch_path(&file).unwrap();
+        assert_eq!(changes.recv().unwrap(), "initial");
+
+        {
+            fs::OpenOptions::new()
+                .write(true)
+                .truncate(true)
+                .open(file)
+                .unwrap()
+                .write_all(b"truncated")
+                .unwrap()
+        }
+        assert_eq!(changes.recv().unwrap(), "truncated");
+
+        assert_eq!(changes.try_recv(), Err(TryRecvError::Empty));
+    }
+
+    #[test]
+    fn handle_flush() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("file");
+        fs::write(&file, "initial").unwrap();
+
+        let (_watcher, changes) = watch_path(&file).unwrap();
+        assert_eq!(changes.recv().unwrap(), "initial");
+
+        let mut openned = File::create(&file).unwrap();
+
+        openned.write_all(b"flushed").unwrap();
+        openned.flush().unwrap();
+        assert_eq!(changes.recv().unwrap(), "flushed");
+
+        openned.write_all(b" and closed").unwrap();
+        drop(file);
+        assert_eq!(changes.recv().unwrap(), "flushed and closed");
+
+        assert_eq!(changes.try_recv(), Err(TryRecvError::Empty));
+    }
+}


### PR DESCRIPTION
currently, the file is checked in a polling fashion, which is kinda heavy load for the filesystem. moving to [notify](https://crates.io/crates/notify) both reduce io and improve responsiveness.

it's also using a [channel](https://doc.rust-lang.org/std/sync/mpsc/fn.channel.html) to send updates instead of a pointer magics which is safer (no unsafe) and potentially faster.

I tried it with vim, sed, shell redirects, on Linux, hopefully is should behave the same everywhere. the modify-data and rename-in-place event works for my use-cases, but I dunno for other editors (but the tests should cover most).
the very specific case of creating an empty file without any content is not handled, as that would make the implementation way more complex.