### PR TITLE
Apply fixes recommended by Clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
@@ -273,23 +273,21 @@ dependencies = [
 
 [[package]]
 name = "const-random"
-version = "0.1.15"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368a7a772ead6ce7e1de82bfb04c485f3db8ec744f72925af5735e29a22cc18e"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
 dependencies = [
  "const-random-macro",
- "proc-macro-hack",
 ]
 
 [[package]]
 name = "const-random-macro"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
  "getrandom",
  "once_cell",
- "proc-macro-hack",
  "tiny-keccak",
 ]
 
@@ -641,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "glicol"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88baa85deca4429ace914f0074d658e3b48cbec3a235dfb8b14b3709e937dab0"
+checksum = "8f16e534842c3f7f95f217d7de809ddcf5a0e36decd46f4bbe6ca46f0b4c22a6"
 dependencies = [
  "glicol_macros",
  "glicol_parser",
@@ -677,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "glicol_macros"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe3af5efb3df27cb73ca3e431af772e846e585bddb59e40ec5a15bf60ee8ec8"
+checksum = "9a19d6bf9a0731afaa18044057c5ede9c07b14c71e6e058c39eade5b30591a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -688,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "glicol_parser"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83cd35536554f0c4e2615b68ba87c6885c972268d48889c701c602826fecac9a"
+checksum = "f63e9b504e7e36346432dba25fb7ff78e6c33fbc1b80981d8b4c4cebe45b7fcd"
 dependencies = [
  "fasteval",
  "glicol_macros",
@@ -702,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "glicol_synth"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c918901608c67bc85a986222ea1351fe6b0b38764e1a55b6024deb6aa8cc17"
+checksum = "408da86dff2130bc6de7df9eb54c946607c5a6cc134c336de3df11b32f697d20"
 dependencies = [
  "arrayvec",
  "dasp_interpolate",
@@ -1135,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "overload"
@@ -1255,12 +1253,6 @@ dependencies = [
  "once_cell",
  "toml_edit",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -2208,18 +2200,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.26"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.26"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.75"
 clap = { version = "4.4.8", features = ["derive"] }
-glicol = { version = "0.13.4", features = ["use-samples"] }
-glicol_synth = "0.13.4"
+glicol = { version = "0.13.4", features = ["use-samples", "use-meta"] }
+glicol_synth = { version = "0.13.4", default-features = false }
 cpal = "0.15.2"
 # chrono = "0.4.23"
-crossterm = "0.27.0"
+crossterm = { version = "0.27.0", default-features = false }
 ratatui = "0.24.0"
-symphonia = { version = "0.5.3", features = ["wav"] }
+symphonia = "0.5.3"
 notify = "6"
 rayon = "1.8.0"
 ringbuf = "0.3"

--- a/src/recent_lines.rs
+++ b/src/recent_lines.rs
@@ -37,8 +37,8 @@ impl RecentLinesBuffer {
     }
 
     /// Get the most recent lines
-    pub fn read(&self) -> Vec<String> {
-        self.lines.iter().cloned().collect()
+    pub fn read(&self) -> impl Iterator<Item = &String> {
+        self.lines.iter()
     }
 }
 
@@ -123,10 +123,10 @@ mod tests {
         let mut last_written = RecentLinesBuffer::new(10);
 
         write!(&mut last_written, "not ended line").unwrap();
-        assert!(last_written.read().is_empty());
+        assert!(last_written.read().next().is_none());
 
         writeln!(&mut last_written, " is now ended").unwrap();
-        assert_eq!(last_written.read(), vec!["not ended line is now ended"]);
+        assert_eq!(last_written.read().collect::<Vec<_>>(), vec!["not ended line is now ended"]);
     }
 
     #[test]
@@ -136,9 +136,9 @@ mod tests {
         writeln!(&mut last_written, "a").unwrap();
         writeln!(&mut last_written, "b").unwrap();
         writeln!(&mut last_written, "c").unwrap();
-        assert_eq!(last_written.read(), vec!["a", "b", "c"]);
+        assert_eq!(last_written.read().collect::<Vec<_>>(), vec!["a", "b", "c"]);
 
         writeln!(&mut last_written, "d").unwrap();
-        assert_eq!(last_written.read(), vec!["b", "c", "d"]);
+        assert_eq!(last_written.read().collect::<Vec<_>>(), vec!["b", "c", "d"]);
     }
 }


### PR DESCRIPTION
This PR does a few things:
1. Applies the fixes recommended by `clippy`. Involved in this was extracting most of the `Atomic`s to being held in a `SampleData` struct, which is then wrapped in an `Arc` to avoid allocating an `Arc` per-Atomic. This fixes clippy's complaint about over-complicated/too many fn arguments
2. Update ahash (to not use the yanked version) and remove some unused features in dependencies
3. Move the terminal setup code to after the initial audio device configuration, to prevent a situation where the terminal is setup and then the program crashes, putting the terminal in a weird state.