### PR TITLE
Adds headless mode and a self-recompiling development target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +227,18 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "clang-sys"
@@ -786,6 +813,29 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys 0.8.3",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "indexmap"
@@ -1890,6 +1940,7 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "chrono",
  "nu-ansi-term",
  "sharded-slab",
  "smallvec",
@@ -2076,6 +2127,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rayon = "1.8.0"
 ringbuf = "0.3"
 walkdir = "2.4.0"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["chrono"] }
 dirs = "5.0.1"
 # dasp_ring_buffer = "0.11.0"
 

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,25 @@
+set export
+current_dir := `pwd`
+
+RUSTFLAGS := "-D warnings"
+
+# print help for Just targets
+help:
+    @just -l
+
+# Build and run binary + args from any directory
+[no-cd]
+run *args:
+    cargo run --manifest-path "${current_dir}/Cargo.toml" -- {{args}}
+
+# Build
+build *args:
+    cargo build {{args}}
+
+# Run Clippy to report and fix lints
+clippy *args:
+    cargo clippy {{args}} --color=always 2>&1 --tests | less -R
+
+# Clean all artifacts
+clean *args:
+    cargo clean {{args}}

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Arguments:
 Options:
   -b, --bpm <BPM>        Set beats per minute (BPM) [default: 120]
   -d, --device <DEVICE>  The audio device to use [default: default]
+  -H, --headless         Disable the TUI
   -h, --help             Print help
   -V, --version          Print version
 ```
@@ -73,3 +74,27 @@ Run the line in your terminal first:
 For example:
 
 `export GLICOL_CLI_SAMPLES_PATH=~/Downloads/samples`
+
+## Development
+
+If you are developing the glicol-cli source code itself, you can setup
+a convenient self-recompiling debug binary alias:
+
+ * Install
+[Just](https://github.com/casey/just?tab=readme-ov-file#readme)
+
+```sh
+cargo install just
+```
+
+ * Put the alias into your shell init (`~/.bashrc`):
+
+```
+# Point this to the Justfile found in your git clone:
+alias glicol-cli='just -f ~/git/vendor/glicol/glicol-cli/Justfile run'
+```
+
+This special `glicol-cli` alias can be run from any directory, and the
+program will automatically recompile itself before running the
+program. You can still provide `glicol-cli` command line arguments as
+normal.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,11 @@ mod watcher;
 use tui::*;
 use watcher::watch_path;
 
+use anyhow::{Context, Result};
+use clap::{CommandFactory, Parser};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::{FromSample, SizedSample, SupportedStreamConfig};
+use glicol::Engine;
 use std::error::Error;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU32, AtomicUsize, Ordering};
@@ -13,13 +18,8 @@ use std::sync::mpsc::TryRecvError;
 use std::sync::{self, Arc};
 use std::time::{Duration, Instant}; // , SystemTime, UNIX_EPOCH
 use std::{io, thread}; // use std::time::{Instant};
-
-use anyhow::{Context, Result};
-use clap::{CommandFactory, Parser};
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::{FromSample, SizedSample, SupportedStreamConfig};
-use glicol::Engine;
 use tracing::error;
+use tracing_subscriber::fmt::{format::FmtSpan, time::ChronoLocal};
 
 pub const RB_SIZE: usize = 200;
 pub const BLOCK_SIZE: usize = 128;
@@ -78,7 +78,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // keep logs
     const RECENT_LINES_COUNT: usize = 100;
-    let console_buffer = recent_lines::register_tracer(RECENT_LINES_COUNT);
 
     // let mut ringbuf_l = [0.0; RB_SIZE];
     // let mut ringbuf_r = [0.0; RB_SIZE];
@@ -252,37 +251,46 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     });
 
-    if !args.headless {
-        // setup terminal
-        enable_raw_mode()?;
-        let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-        let backend = CrosstermBackend::new(stdout);
-        let mut terminal = Terminal::new(backend)?;
+    match args.headless {
+        true => {
+            tracing_subscriber::fmt()
+                .with_timer(ChronoLocal::new(String::from("%H:%M:%S%.3f")))
+                .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+                .init();
+        }
+        false => {
+            // setup terminal
+            let console_buffer = recent_lines::register_tracer(RECENT_LINES_COUNT);
+            enable_raw_mode()?;
+            let mut stdout = io::stdout();
+            execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+            let backend = CrosstermBackend::new(stdout);
+            let mut terminal = Terminal::new(backend)?;
 
-        let tick_rate = Duration::from_millis(16);
-        let res = run_app(
-            console_buffer,
-            &mut terminal,
-            tick_rate,
-            sample_data,
-            // scope,
-            info,
-        );
+            let tick_rate = Duration::from_millis(16);
+            let res = run_app(
+                console_buffer,
+                &mut terminal,
+                tick_rate,
+                sample_data,
+                // scope,
+                info,
+            );
 
-        // restore terminal
-        disable_raw_mode()?;
-        execute!(
-            terminal.backend_mut(),
-            LeaveAlternateScreen,
-            DisableMouseCapture
-        )?;
-        terminal.show_cursor()?;
-        match res {
-            Ok(ExitStatus::ExitAll) => std::process::exit(0),
-            Ok(ExitStatus::KeepAudio) => (),
-            Err(e) => println!("{e:?}"),
-        };
+            // restore terminal
+            disable_raw_mode()?;
+            execute!(
+                terminal.backend_mut(),
+                LeaveAlternateScreen,
+                DisableMouseCapture
+            )?;
+            terminal.show_cursor()?;
+            match res {
+                Ok(ExitStatus::ExitAll) => std::process::exit(0),
+                Ok(ExitStatus::KeepAudio) => (),
+                Err(e) => println!("{e:?}"),
+            };
+        }
     }
     audio_thread.join().unwrap();
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant}; // , SystemTime, UNIX_EPOCH
 use std::{io, thread}; // use std::time::{Instant};
 
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{FromSample, SizedSample, SupportedStreamConfig};
 use glicol::Engine;
@@ -60,6 +60,12 @@ struct Args {
 
 #[allow(unused_must_use)]
 fn main() -> Result<(), Box<dyn Error>> {
+    // Print help screen if no args provided:
+    if std::env::args().len() == 1 {
+        Args::command().print_help()?;
+        println!();
+        return Ok(());
+    }
     let args = Args::parse();
     let path = args.file;
     // let scope = args.scope;


### PR DESCRIPTION
I am just getting a few things setup to develop on glicol-cli, and I have made a few improvements. If you like, I can split these out into separate PRs. 

 * Checks if the user forgot to add any arguments, and prints the full help screen if so.

 * Adds a `-H` / `--headless` mode to disable the TUI.

 * Adds a `Justfile` and a `run` target so you can setup a shell alias, that can be run from any directory, and to have `glicol-cli` automatically recompile itself before each run.